### PR TITLE
✨ feat: レンダラをmathjaxからKaTeXに変更

### DIFF
--- a/assets/js/latex.js
+++ b/assets/js/latex.js
@@ -1,19 +1,7 @@
-// エディタとプレビュー領域、ボタンの取得
 const editor = document.getElementById("editor");
 const preview = document.getElementById("preview");
 const openCHTMLBtn = document.getElementById("openCHTMLBtn");
 const LOCAL_STORAGE_KEY = "latexEditorContent";
-
-// MathJaxの設定
-MathJax = {
-  tex: {
-    inlineMath: [
-      ["$", "$"],
-      ["\\(", "\\)"],
-    ],
-  },
-  chtml: { scale: 1, matchFontHeight: true },
-};
 
 // ローカルストレージから保存された内容を読み込み
 window.addEventListener("load", () => {
@@ -31,71 +19,54 @@ editor.addEventListener("input", () => {
   updatePreview();
 });
 
-// プレビューを更新する関数
+// プレビューを更新する関数（KaTeX使用）
 function updatePreview() {
   const latexText = editor.value;
-  preview.innerHTML = `\\[${latexText}\\]`;
-  if (typeof MathJax !== "undefined" && MathJax.typesetPromise) {
-    MathJax.typesetPromise([preview]).catch((err) =>
-      console.error("MathJax Error:", err)
-    );
-  } else {
-    console.error("MathJax is not loaded or typesetPromise is unavailable.");
+  try {
+    const html = katex.renderToString(latexText, {
+      throwOnError: false,
+      displayMode: true,
+    });
+    preview.innerHTML = html;
+  } catch (err) {
+    preview.innerHTML =
+      `<span style="color: red;">Error rendering LaTeX</span>`;
+    console.error("KaTeX Error:", err);
   }
 }
 
-// CHTMLを新しいタブで開くボタンの機能
-openCHTMLBtn.addEventListener("click", async () => {
+// CHTMLを新しいタブで開くボタンの機能（KaTeX対応）
+openCHTMLBtn.addEventListener("click", () => {
   try {
-    // MathJaxの処理を完了させる
-    await MathJax.typesetPromise([preview]);
-    const mathElement = preview.querySelector("mjx-container");
-    if (!mathElement) {
-      console.error("CHTML element not found!");
-      return;
-    }
-    const getAccessibleCSS = () => {
-      const cssRules = [];
-      Array.from(document.styleSheets).forEach((styleSheet) => {
-        try {
-          // `cssRules`が安全に読み取れる場合のみ処理を続行
-          if (styleSheet.cssRules) {
-            Array.from(styleSheet.cssRules).forEach((rule) => {
-              cssRules.push(rule.cssText);
-            });
-          }
-        } catch (e) {
-          console.warn(
-            "Cannot access CSS rules from a stylesheet:",
-            styleSheet.href,
-          );
-        }
-      });
-      return cssRules.join("\n");
-    };
-    const cssText = getAccessibleCSS();
+    const latexText = editor.value;
+    const html = katex.renderToString(latexText, {
+      throwOnError: false,
+      displayMode: true,
+    });
 
-    // CHTMLの外部CSSを含む完全なHTMLを生成
-    const chtml = `
+    const cssHref =
+      "https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css";
+
+    const fullHTML = `
       <!DOCTYPE html>
       <html lang="en">
       <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>MathJax CHTML Output</title>
-        <style>${cssText}</style>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>KaTeX Output</title>
+        <link rel="stylesheet" href="${cssHref}" />
       </head>
       <body>
-        ${mathElement.outerHTML}
+        ${html}
       </body>
       </html>
     `;
 
-    // データURLを生成し、新しいタブで開く
-    const chtmlBlob = new Blob([chtml], { type: "text/html" });
-    const chtmlURL = URL.createObjectURL(chtmlBlob);
-    window.open(chtmlURL, "_blank");
+    const blob = new Blob([fullHTML], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    window.open(url, "_blank");
   } catch (err) {
-    console.error("Error generating or opening CHTML:", err);
+    console.error("Error generating or opening KaTeX output:", err);
   }
 });
+

--- a/latex.html
+++ b/latex.html
@@ -6,11 +6,11 @@ js: latex
 ---
 
 <h1>LaTeX エディタ</h1>
-<script
-  id="MathJax-script"
-  async
-  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"
-></script>
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css"
+/>
+<script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script src="assets/js/svg2pdf.umd.min.js"></script>
 


### PR DESCRIPTION
# 実施内容
- LaTeXの数式レンダラをMathJaxからKaTeXに変更
- レンダラが読み込まれない問題がなくなる（開発環境では）